### PR TITLE
Sort the sprint data by displayName

### DIFF
--- a/scripts/DropPlanHelper.js
+++ b/scripts/DropPlanHelper.js
@@ -33,7 +33,7 @@ function render(isSaving, data) {
                 if (personRow.avatar) {
                     result = result +  "<img class='assignedToAvatar' src='" + personRow.avatar + "'/>"
                 }
-                result = result + "<div class='assignedToName'>" + personRow.assignedTo + "</div>"
+                result = result + "<div class='assignedToName'>" + personRow.assignedTo.displayName + "</div>"
 
                 if (personRow.TotalCapacity > 0) {
                     var cssClass = 'visual-progress-total visual-progress-overallocated';

--- a/scripts/components/SprintData.js
+++ b/scripts/components/SprintData.js
@@ -294,6 +294,6 @@ function SprintData(workitems, repository, viewByTasks) {
             }
         }
 
-        return result.sort(function (a, b) { return a.assignedTo.localeCompare(b.assignedTo) });
+        return result.sort(function (a, b) { return a.assignedTo.displayName.localeCompare(b.assignedTo.displayName) });
     }
 }


### PR DESCRIPTION
Not sure whether the API has changed recently but `assignedTo` is an object which you can't do `localeCompare` on, so changed to sort by `displayName` which I'm assuming is what it was doing before.