### PR TITLE
fix: Remove double semicolon

### DIFF
--- a/scripts/DateHealpers.js
+++ b/scripts/DateHealpers.js
@@ -58,7 +58,7 @@ Date.prototype.getGMT = function() {
         this.getUTCHours(),
         this.getUTCMinutes(),
         this.getUTCSeconds(),
-    );;
+    );
 };
 
 Date.prototype.ConvertGMTToServerTimeZone = function() {


### PR DESCRIPTION
This may be partly an IE fix, but it makes sense for other browers too