### PR TITLE
Stop GetWorkitemsByIdsFromAll from returning undefined in array.

### DIFF
--- a/scripts/components/SprintData.js
+++ b/scripts/components/SprintData.js
@@ -143,7 +143,7 @@ function SprintData(workitems, repository, existingSprint) {
     this.GetWorkitemsByIdsFromAll = function (ids) {
         return ids.map(
             (id)=> this.GetWorkitemByIdFromAll(id)
-        );
+        ).filter((workItem) => workItem);
     }
 
     this.GetAssignToNameById = function(id){

--- a/vss-extension.json
+++ b/vss-extension.json
@@ -1,7 +1,7 @@
 {
     "manifestVersion": 1,
     "id": "Drop-plan-extension#{testing-flag}",
-    "version": "2.0.0#{beta-flag}",
+    "version": "2.0.1#{beta-flag}",
     "name": "Sprint Drop Plan#{testing-flag}",
     "description": "Plan and track your sprint with a calendar based view.",
     "publisher": "yanivsegev",


### PR DESCRIPTION
Stop `GetWorkitemsByIdsFromAll` from returning undefined in array if parent is not in `AllWits`.
This fixes an issue where the plan doesn't load if the parent isn't in the list of items in `AllWits`