### PR TITLE
Move adding of CSS class so that it always runs

### DIFF
--- a/scripts/DropPlanHelper.js
+++ b/scripts/DropPlanHelper.js
@@ -77,9 +77,9 @@ function render(isSaving, data) {
                         if (task.isWitTask){
                             parentId = task.workItem.GetParentId();
                             parentWit = sprint.GetWorkitemByIdFromAll(parentId);
+                            result = result + " witParentId=" + parentId + " class='task tooltip ";
                             if(parentWit){
                                 partnerWorktemId = sprint.AllWits.indexOf(parentWit);
-                                result = result + " witParentId=" + parentId + " class='task tooltip ";
 
                                 if(task.workItem.Activity && parentWit.childActivities) {
                                     const activityIndex = activityTypeOrder.findIndex(

--- a/vss-extension.json
+++ b/vss-extension.json
@@ -1,7 +1,7 @@
 {
     "manifestVersion": 1,
     "id": "Drop-plan-extension#{testing-flag}",
-    "version": "2.0.1#{beta-flag}",
+    "version": "2.0.2#{beta-flag}",
     "name": "Sprint Drop Plan#{testing-flag}",
     "description": "Plan and track your sprint with a calendar based view.",
     "publisher": "yanivsegev",


### PR DESCRIPTION
In my haste to fix the earlier crashing issues I popped an `if` around a chunk of code I'd added that needed a valid `parentWit`.
Unfortunately there was a line adding classes to the WitTasks inside the new `if`.

This fixes my mistake and returns the line that adds the classes even if the item doesn't have a parent in the sprint.

I've tested in all the situations that failed earlier, in both Agile & Scrum.