### PR TITLE
Fixes #108 - Duplicating first activity capacity

### DIFF
--- a/scripts/components/VSSRepository.js
+++ b/scripts/components/VSSRepository.js
@@ -241,7 +241,7 @@ function VSSRepository() {
                     result = value.activities.reduce(
                         function (runningTotal, current){
                             return runningTotal + current.capacityPerDay;
-                        }, value.activities[0].capacityPerDay
+                        }, 0
                     ) || 6;
                 }
             }

--- a/vss-extension.json
+++ b/vss-extension.json
@@ -1,7 +1,7 @@
 {
     "manifestVersion": 1,
     "id": "Drop-plan-extension#{testing-flag}",
-    "version": "2.0.4#{beta-flag}",
+    "version": "2.0.5#{beta-flag}",
     "name": "Sprint Drop Plan#{testing-flag}",
     "description": "Plan and track your sprint with a calendar based view.",
     "publisher": "yanivsegev",


### PR DESCRIPTION
Fixes #108  where we were including the first activities capacity twice in the calculation, which for many people seemed to double it.
Have updated my testing scenario to show this. 

(We've already fixed 80, but I didn't link it correctly, so Fixes #80 )