### PR TITLE
For task siblings with more than 10 siblings, change to status bar.

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,12 +44,13 @@ Happy coding :-)
 
 ## Change Log ##
 
-### 2.1.1 -> 2.1.4 ###
+### 2.1.1 -> 2.1.5 ###
 
 BugFixes:
 
 1. Improving error handling on saving
 2. Settings weren't scoped to project (#113)
+3. Related tasks with more than 11 siblings spill the status outside the item.
 
 ### 2.1.0 ###
 

--- a/Styles/main.css
+++ b/Styles/main.css
@@ -133,6 +133,17 @@ body{
     padding: 2px;
 }
 
+.relatedTaskPCBox {
+    font-size: smaller;
+    text-overflow: ellipsis;
+    overflow: hidden;
+    white-space: nowrap;
+    width: calc(100% - 22px);
+    padding-top: 0px;
+    border: 1px solid white;
+    height: 16px;
+}
+
 .taskOverDue[style]{
     background: var(--taskOverDue);
 }

--- a/scripts/DropPlanHelper.js
+++ b/scripts/DropPlanHelper.js
@@ -239,7 +239,33 @@ function render(isSaving, data) {
                                 }
                             );
 
-                            if (relatedItems.length > 1){
+                            if (relatedItems.length > 10){
+                                //If more than 10 siblings, show a progress bar.
+                                const countOfSiblingStates=relatedItems.reduce((agg, item) => {
+                                    if (agg[item.State]){
+                                        agg[item.State].count++;
+                                    } else {
+                                        agg[item.State] = {count:1, stateColor: item.stateColor}
+                                    }
+                                    return agg;
+                                },{})
+
+                                // Produce the style and text for the progress bar, by calculating the percentage of each state and then using that to create a gradient.
+                                const siblingStyleAndText = (Object.keys(countOfSiblingStates).reduce((output, key)=>{
+                                    const state=countOfSiblingStates[key];
+                                    const percent=(state.count/relatedItems.length)*100;
+
+                                    output.style.push(`#${state.stateColor} ${output.lastPercent}%`);
+                                    output.style.push(`#${state.stateColor} ${(output.lastPercent+percent)}%`)
+                                    output.text.push(`${state.count} ${key}`)
+                                    output.lastPercent =+ percent;
+                                    return output;
+                                }, {style: [], text:[], lastPercent: 0}))
+
+                                result = result + "<div class='relatedTaskBox relatedTaskPCBox' style='background: linear-gradient(90deg, ";
+                                result = result + siblingStyleAndText.style.join(", ");
+                                result = result + `)'>${siblingStyleAndText.text.join(", ")}</div>`;
+                            } else if (relatedItems.length > 1){
                                 result = result + "<div class='relatedTaskBox'>";
 
                                 relatedItems.forEach(function(item,index) {

--- a/scripts/components/VSSSettingsRepository.js
+++ b/scripts/components/VSSSettingsRepository.js
@@ -62,7 +62,7 @@ function VSSSettingsRepository() {
                     let otherClient = TFS_Wit_WebApi.getClient();
 
                     var teamContext = { projectId: _this._data.VssContext.project.id, teamId: _this._data.VssContext.team.id, project: "", team: "" };
-
+                    console.log("Team context ", teamContext);
                     const extensionDataReady = /** @type {Promise<void>} */(new Promise(function(resolve,reject){
                         VSS.getService(VSS.ServiceIds.ExtensionData).then(function (res){
                             _this._data.dataService = res;

--- a/vss-extension.json
+++ b/vss-extension.json
@@ -1,7 +1,7 @@
 {
     "manifestVersion": 1,
     "id": "Drop-plan-extension#{testing-flag}",
-    "version": "2.1.4#{beta-flag}",
+    "version": "2.1.5#{beta-flag}",
     "name": "Sprint Drop Plan#{testing-flag}",
     "description": "Plan and track your sprint with a calendar based view.",
     "publisher": "yanivsegev",


### PR DESCRIPTION
This adds a console.log to see if we're missing the project or the team id in the settings page.
It also resolves the graphical issue seen in #115 when you have more than 11 sibling tasks by replacing the related task status dots with a status bar & text summary.