### PR TITLE
Fix non working day issue with negative time zones

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,19 +44,20 @@ Happy coding :-)
 
 ## Change Log ##
 
-### 2.1.1 -> 2.1.7 ###
+### 2.1.1 -> 2.1.8 ###
 
 BugFixes:
 
-1. Improving error handling on saving
-2. Settings weren't scoped to project (#113)
+1. Improving error handling on saving.
+2. Settings weren't scoped to project. (#113)
 3. Related tasks with more than 11 siblings spill the status outside the item.
 4. Warnings weren't hiding if the settings was switched off.
+5. Fixed issue with users in negative timezones being unable to place tasks on the first day of the sprint. (#118)
 
 ### 2.1.0 ###
 
-1. See task type from icon or colour (theme dependant) (#59)
-2. Add option to hide team non-working days (e.g., hide weekends/national holidays) (#9, #57)
+1. See task type from icon or colour (theme dependant). (#59)
+2. Add option to hide team non-working days (e.g., hide weekends/national holidays). (#9, #57)
 3. See all people on the plan with allocated capacity. (#73)
 4. Add ability to right click to add/remove individual team members as on leave for that day.
 5. Add ability to use Stories instead of Tasks on the Drop Plan for teams that do not use the lowest level of work item type.
@@ -72,8 +73,8 @@ Bugfixes #75, #84, #98, #97, #102, #106, #108, #110.
 2. Add task completion progress.
 3. Add warning for tasks where the activities are out of order sequence (E.g., Testing before Development).
 4. Add warning for Tasks that are planned out of parent sequence.
-5. Add ability to filter on Activity and tags (#89)
-6. Use all the configured capacity for a user (#80)
-7. Reduce the number of calls the Plan makes when active, and vastly reduce when the plan is in the background (#63)
+5. Add ability to filter on Activity and tags. (#89)
+6. Use all the configured capacity for a user. (#80)
+7. Reduce the number of calls the Plan makes when active, and vastly reduce when the plan is in the background. (#63)
 8. Other bugfixes.
 9. Updated dependences to latest.

--- a/scripts/components/VSSRepository.js
+++ b/scripts/components/VSSRepository.js
@@ -340,7 +340,7 @@ function VSSRepository() {
     }
 
     this.IsTeamDayOff = (dateToCheck) => {
-        const date=dateToCheck.yyyymmdd(), day=dateToCheck.getDay()
+        const gmtDateToCheck=dateToCheck.getGMT(), date=gmtDateToCheck.yyyymmdd(), day=gmtDateToCheck.getDay()
         var dayOff = false;
 
         if (isDayInRange(this._data.daysOff.daysOff, date)) dayOff = true;
@@ -354,7 +354,7 @@ function VSSRepository() {
         if (this._data.userSettings.ShowTeamNonWorkingDays){
             return true;
         }
-        const date=dateToCheck.yyyymmdd(), day=dateToCheck.getDay()
+        const gmtDateToCheck=dateToCheck.getGMT(), date=gmtDateToCheck.yyyymmdd(), day=gmtDateToCheck.getDay()
 
         if (isDayInRange(this._data.daysOff.daysOff, date)) return false;
 

--- a/styles/main.css
+++ b/styles/main.css
@@ -55,7 +55,9 @@ body{
 .task {
     height: 65px;
     background: white;
-    z-index: 3;
+    /* 
+    Do not put a z-index on the task if you want the warning popovers to work in day 1 of the sprint.
+    */
 }
 
 .taskDiv

--- a/vss-extension.json
+++ b/vss-extension.json
@@ -1,7 +1,7 @@
 {
     "manifestVersion": 1,
     "id": "Drop-plan-extension#{testing-flag}",
-    "version": "2.1.7#{beta-flag}",
+    "version": "2.1.8#{beta-flag}",
     "name": "Sprint Drop Plan#{testing-flag}",
     "description": "Plan and track your sprint with a calendar based view.",
     "publisher": "yanivsegev",


### PR DESCRIPTION
This fixes #118.

The day off calculation was using the datetime with the timezone but compared to the date/day provided without a timezone.
Basically the date was being returned as the day before due to the timezone being negative.

Also fixed an issue where the task warnings weren't fully visible for a task in the first day of the sprint.
This was due to a z-index being applied to the task, which doesn't seem to be required.
