### PR TITLE
fix #121 - Add highlight by status and parent

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,7 +44,11 @@ Happy coding :-)
 
 ## Change Log ##
 
-### 2.1.1 -> 2.1.9 ###
+### 2.2.0 ###
+
+Now able to Highlight on either Status colour, or Parent in addition to the existing Area path.
+
+### 2.1.1 -> 2.1.12 ###
 
 BugFixes:
 

--- a/index.html
+++ b/index.html
@@ -17,8 +17,14 @@
                     <!-- <button class='refreshPlanBtn' onclick='refreshPlan();'>Refresh Tasks</button> -->
                 </div>
                 <div>
-                    <input id="showAreaPath" type="checkbox" onclick="$('body').toggleClass('showareapath');" />
-                    <label for="showAreaPath">Highlight same area path</label>
+                    <!--<input id="showAreaPath" type="checkbox" onclick="$('body').toggleClass('showareapath');" />-->
+                    Highlight:
+                    <select id="highlight" onchange="changeHighlight(this.options[this.selectedIndex].value)">
+                        <option value="">None</option>
+                        <option value="areapath">Area Path</option>
+                        <option value="Status">Status</option>
+                        <option value="Parent">Parent</option>
+                    </select>
                 </div>
                 <div>
                     <input id="showPBIs" type="checkbox" onclick="switchViewByTasks(!($('#showPBIs').prop('checked')));" />
@@ -34,8 +40,8 @@
                     <select id="filterArea">
                         <option value="AllSearchable">All</option>
                         <option value="Activity">Activity</option>
-                        <option value="AreaPath">AreaPath</option>
-                        <option value="AssignedTo">AssignedTo</option>
+                        <option value="AreaPath">Area Path</option>
+                        <option value="AssignedTo">Assigned To</option>
                         <option value="Title">Title</option>
                         <option value="ParentTags">Parent Tags</option>
                         <option value="ParentTitle">Parent Title</option>

--- a/scripts/DropPlanHelper.js
+++ b/scripts/DropPlanHelper.js
@@ -131,7 +131,7 @@ function render(isSaving, data) {
                                         result = result + " taskOutOfSequence ";
                                     }
                                 }
-                                
+
                                 const predecessors = sprint.GetWorkitemsByIdsFromAll(parentWit.GetPredecessorIds());
                                 for(const predecessor of predecessors){
                                     const lastChild=predecessor.GetLastChild(useActivityTypeInDependencyTracking ? task.workItem.Activity : undefined);
@@ -170,18 +170,22 @@ function render(isSaving, data) {
                         } else {
                             result = result + ` TaskType${task.workItem.workItemConfig.cssName}`;
                         }
-
+                        result = result + ` Task${task.workItem.workItemConfig.cssName}Status${toCssName(task.workItem.State)}`;
 
                         result = result + " taskAreaPath" + task.areaPath.id + " ";
+                        result = result + ` taskParent${task.workItem.ParentIndex % 10} taskParent${Math.trunc(task.workItem.ParentIndex / 10)}0 `;
                         var contentWidth = (colWidth * task.total - 26);
                         result = result + "' style='width:" + contentWidth + "px; ";
 
+                        // use a cool tick with a css variable to be able to optionally override the background-image being applied here.
+                        result = `${result}background-image: var(--backgroundImage, `
                         if (task.isWitTask){
                             var remain = task.workItem.RemainingWork;
                             //grab the percentage, but don't let it go over 90% so that it's visually obvious that the ticket isn't complete
                             const percentComplete = Math.min(Math.floor((task.workItem.CompletedWork / task.workItem.TotalWork) *100), 90);
-                            if (remain != undefined && remain != "") result = `${result}background-image: linear-gradient(90deg, color-mix(in srgb, var(--taskDone), transparent 50%) calc(${percentComplete}% + 6px), #FFFFFF00 0);`;
+                            if (remain != undefined && remain != "") result = `${result}linear-gradient(90deg, color-mix(in srgb, var(--taskDone), transparent 50%) calc(${percentComplete}% + 6px), #FFFFFF00 0)`;
                         }
+                        result = `${result});`
 
                         result = result + "'>";
 
@@ -206,14 +210,13 @@ function render(isSaving, data) {
 
                         result = result + "<div class='taskTitle'><div class='taskTypeIcon'></div>"
                         if (warnings.length){
-                            // style='width: min(" + (colWidth*2.5) + "px, max(" + contentWidth + "px, " + (colWidth * 1.5) + "px))'
                             result = result + "<div class='taskWarning'><div class='taskWarningIcon'>⚠</div><div class='taskWarningTooltip' >";
                             warnings.forEach(function (warning){
                                 result = result + "<p>" + warning +"</p>";
                             });
                             result = result + "</div></div>"
                         }
-                        
+
                         result = result + "<span class='openWit'>" + task.workItem.Title + "</span></div>";
                         if (parentWit){
                             let relatedItems = [];
@@ -432,9 +435,8 @@ function attachEvents() {
             let menuItems = [];
             
             var member = sprint.GetAssignToNameById($(this).closest('tr')[0].cells[0].attributes["assignedtoid"].value)?.OriginalAssignedTo;
-            const memberCapacity = repository._data.teamMemberCapacities.find((e)=>e.teamMember.id == member?.id);
         
-            if(memberCapacity){
+            if(member?.id){
                 const currentCell=$(this).closest('td');
                 var date = new Date(currentCell[0].attributes["cellDate"].value);
                 if (currentCell.hasClass("taskDayOff") && !currentCell.hasClass("taskTeamDayOff")) {
@@ -637,3 +639,6 @@ function updateWorkItemAssignTo(witId, assignedTo) {
     }
 }
 
+function toCssName(name){
+    return name.replace(/[^a-zA-Z0-9-_]/ig,'');
+}

--- a/scripts/DropPlanVSS-Settings.js
+++ b/scripts/DropPlanVSS-Settings.js
@@ -1,5 +1,5 @@
 var repository = new VSSSettingsRepository();
-
+var showFailAlerts = true;
 window.addEventListener("message", receiveMessage, false);
 
 function receiveMessage(event) {
@@ -27,11 +27,26 @@ function reportProgress(msg){
 }
 
 function alertUser(msg, e){
+    if (!msg){
+        msg = e?.serverError?.value?.Message || e?.message || "Unknown error";
+    }
+
     var logMsg = "Alert User: [" + msg + "]";
-    console.log(msg);
-    if (e) console.log(e);
-    if (window._trackJs && typeof trackJs != "undefined") { trackJs.track(logMsg); }
-    alert(msg);
+
+    if (
+            !(e?.message?.indexOf('Rule Error') > 0) // don't log "rule validation" errors
+            && !(e?.message?.indexOf('Status code 0:') > 0) //don't log "server unavailable" errors
+        )
+    {
+        console.error(logMsg, e);
+    } else {
+        console.log(logMsg, e);
+    }
+    if (showFailAlerts){
+        if (!(e?.message?.indexOf('Status code 0:') > 0)){
+            alert(msg);
+        }
+    }
 }
 
 function switchPlanningIssues(enabled){
@@ -71,5 +86,5 @@ try{
 		$(".messageBoxContainer").remove();
 	});
 } catch (error) {
-	alertUser(error);
+	alertUser(undefined, error);
 }

--- a/scripts/DropPlanVSS.js
+++ b/scripts/DropPlanVSS.js
@@ -52,6 +52,14 @@ function switchViewNonWorkingTeamDays(showNonWorkingTeamDays){
     });
 }
 
+function changeHighlight(newHighlight){
+    $('body').removeClass(`show${sprint.Highlight}`);
+    sprint.Highlight = newHighlight;
+    if(sprint.Highlight){
+        $('body').addClass(`show${sprint.Highlight}`);
+    }
+}
+
 
 var timerid;
 $("#filterBy").on("input", function(e) {
@@ -302,15 +310,15 @@ function alertUser(msg, e){
     
     if (
             !(e?.message?.indexOf('Rule Error') > 0) // don't log "rule validation" errors
-            && !(reason?.message?.indexOf('Status code 0:') > 0) //don't log "server unavailable" errors 
-        ) 
+            && !(e?.message?.indexOf('Status code 0:') > 0) //don't log "server unavailable" errors
+        )
     {
         console.error(logMsg, e);
     }else{
         console.log(logMsg, e);
     }
     if (showFailAlerts){
-        if (!(reason?.message?.indexOf('Status code 0:') > 0)){
+        if (!(e?.message?.indexOf('Status code 0:') > 0)){
             alert(msg);
         }
     }

--- a/scripts/components/SprintData.js
+++ b/scripts/components/SprintData.js
@@ -2,6 +2,7 @@ function SprintData(workitems, repository, existingSprint) {
     this.RawWits = workitems;
     this.Wits = [];
     this.AllWits = [];
+    ParentIndex = [];
 
     this.Repository = repository;
     this.StartDate = new Date(repository.IterationStartDate.toISOString()).getGMT();
@@ -75,6 +76,7 @@ function SprintData(workitems, repository, existingSprint) {
                         parent.childActivities[activity]={MinStart: item.StartDate, MaxFinish: item.FinishDate};
                     }
                 }
+                item.ParentIndex=getIndexOrAdd(parentId);
             }
         });
 
@@ -388,5 +390,16 @@ function SprintData(workitems, repository, existingSprint) {
             result.push(newName);
             this.nameById[names[AssignedToComboName].id] = { OriginalAssignedTo: {...OriginalAssignedTo, displayName:OriginalAssignedTo?.displayName?.split("<")[0].trim() || ""} };
         }
+    }
+
+    function getIndexOrAdd(parentId) {
+        let index = ParentIndex.indexOf(parentId);
+    
+        if (index === -1) {
+            ParentIndex.push(parentId);
+            index = ParentIndex.length - 1;
+        }
+    
+        return index;
     }
 }

--- a/styles/main.css
+++ b/styles/main.css
@@ -476,37 +476,103 @@ canvas {
 
 
 .showareapath .taskAreaPath1 {
-    background:#E0FFFF; 
+    background:#E0FFFF;
 }
 .showareapath .taskAreaPath2 {
-    background:#FAFAD2; 
+    background:#FAFAD2;
 }
 .showareapath .taskAreaPath3 {
-    background:#90EE90; 
+    background:#90EE90;
 }
 .showareapath .taskAreaPath4 {
-    background:#87CEFA; 
+    background:#87CEFA;
 }
 .showareapath .taskAreaPath5 {
-    background:#98FB98; 
+    background:#98FB98;
 }
 .showareapath .taskAreaPath6 {
-    background:#D8BFD8; 
+    background:#D8BFD8;
 }
 .showareapath .taskAreaPath7 {
-    background:#FFC0CB; 
+    background:#FFC0CB;
 }
 
 .showareapath .taskAreaPath8 {
-    background:#7FFFD4; 
+    background:#7FFFD4;
 }
 
 .showareapath .taskAreaPath9 {
-    background:#ADD8E6; 
+    background:#ADD8E6;
 }
 
 .showareapath .taskAreaPath10 {
-    background:#F08080; 
+    background:#F08080;
+}
+
+.showParent .task.taskParent1 {
+    background-color:#E0FFFF;
+}
+.showParent .task.taskParent2 {
+    background-color:#FAFAD2;
+}
+.showParent .task.taskParent3 {
+    background-color:#90EE90;
+}
+.showParent .task.taskParent4 {
+    background-color:#87CEFA;
+}
+.showParent .task.taskParent5 {
+    background-color:#98FB98;
+}
+.showParent .task.taskParent6 {
+    background-color:#D8BFD8;
+}
+.showParent .task.taskParent7 {
+    background-color:#FFC0CB;
+}
+
+.showParent .task.taskParent8 {
+    background-color:#7FFFD4;
+}
+
+.showParent .task.taskParent9 {
+    background-color:#ADD8E6;
+}
+
+.showParent .task.taskParent0 {
+    background-color:#F08080;
+}
+
+.showParent .task.taskParent00 {
+    --backgroundImage: none
+}
+
+.showParent .task.taskParent10 {
+    --backgroundImage: linear-gradient(45deg, white 25%, transparent 25%, transparent 75%, white 75%, white),
+                        linear-gradient(45deg, white 25%, transparent 25%, transparent 75%, white 75%, white);
+    background-size: 20px 20px;
+    background-position: 0 0, 10px 10px;
+}
+.showParent .task.taskParent20 {
+    --backgroundImage: linear-gradient(115deg, transparent 75%, white 75%),
+                        linear-gradient(245deg, transparent 75%, white 75%),
+                        linear-gradient(115deg, transparent 75%, white 75%),
+                        linear-gradient(245deg, transparent 75%, white 75%) ;
+    background-size: 15px 30px;
+    background-position: 0 0, 0 0,  7px -15px, 7px -15px;
+}
+.showParent .task.taskParent30 {
+    --backgroundImage: linear-gradient(90deg, transparent 50%, white 50%);
+    background-size: 20px 20px;
+}
+.showParent .task.taskParent40 {
+    --backgroundImage: linear-gradient(transparent 50%, white 50%);
+    background-size: 20px 20px;
+}
+.showParent .task.taskParent50 {
+    --backgroundImage: linear-gradient(90deg, rgba(127,127,127,.5) 50%, transparent 50%),
+                        linear-gradient(rgba(127,127,127,.5) 50%, transparent 50%);
+    background-size:20px 20px;
 }
 
 #tasksTable .sameParent{

--- a/styles/modern.css
+++ b/styles/modern.css
@@ -134,6 +134,65 @@ input::placeholder {
     background:#F0808077;
 }
 
+.showParent .task.taskParent1 {
+    background-color:#E0FFFF77;
+}
+.showParent .task.taskParent2 {
+    background-color:#FAFAD277;
+}
+.showParent .task.taskParent3 {
+    background-color:#90EE9077;
+}
+.showParent .task.taskParent4 {
+    background-color:#87CEFA77;
+}
+.showParent .task.taskParent5 {
+    background-color:#98FB9877;
+}
+.showParent .task.taskParent6 {
+    background-color:#D8BFD877;
+}
+.showParent .task.taskParent7 {
+    background-color:#FFC0CB77;
+}
+.showParent .task.taskParent8 {
+    background-color:#7FFFD477;
+}
+.showParent .task.taskParent9 {
+    background-color:#ADD8E677;
+}
+.showParent .task.taskParent0 {
+    background-color:#F0808077;
+}
+
+.showParent .task.taskParent10 {
+    --backgroundImage: linear-gradient(45deg, var(--background-color) 25%, transparent 25%, transparent 75%, var(--background-color) 75%, var(--background-color)),
+                        linear-gradient(45deg, var(--background-color) 25%, transparent 25%, transparent 75%, var(--background-color) 75%, var(--background-color));
+    background-size: 20px 20px;
+    background-position: 0 0, 10px 10px;
+}
+.showParent .task.taskParent20 {
+    --backgroundImage: linear-gradient(115deg, transparent 75%, var(--background-color) 75%),
+                        linear-gradient(245deg, transparent 75%, var(--background-color) 75%),
+                        linear-gradient(115deg, transparent 75%, var(--background-color) 75%),
+                        linear-gradient(245deg, transparent 75%, var(--background-color) 75%) ;
+    background-size: 15px 30px;
+    background-position: 0 0, 0 0,  7px -15px, 7px -15px;
+}
+.showParent .task.taskParent30 {
+    --backgroundImage: linear-gradient(90deg, transparent 50%, var(--background-color) 50%);
+    background-size: 20px 20px;
+}
+.showParent .task.taskParent40 {
+    --backgroundImage: linear-gradient(transparent 50%, var(--background-color) 50%);
+    background-size: 20px 20px;
+}
+.showParent .task.taskParent50 {
+    --backgroundImage: linear-gradient(90deg, rgba(127,127,127,.5) 50%, transparent 50%),
+                        linear-gradient(rgba(127,127,127,.5) 50%, transparent 50%);
+    background-size:20px 20px;
+}
+
 /* Style for the right-click menu */
 .right-click-menu {
     background-color: var(--background-color,rgba(255, 255, 255, 1));

--- a/vss-extension.json
+++ b/vss-extension.json
@@ -1,7 +1,7 @@
 {
     "manifestVersion": 1,
     "id": "Drop-plan-extension#{testing-flag}",
-    "version": "2.1.12#{beta-flag}",
+    "version": "2.2.0#{beta-flag}",
     "name": "Sprint Drop Plan#{testing-flag}",
     "description": "Plan and track your sprint with a calendar based view.",
     "publisher": "yanivsegev",


### PR DESCRIPTION
This adds the ability to highlight tasks by either status or parent.

Fixed a minor bug in the recently changed error handling where a variable in the copied code didn't exist.

Added a fix for if the activities array didn't exist. `teamMember?.activities?`

Added a fix where you weren't able to mark a day off if the user didn't already have capacity.

Added some typing into the settings registry, start of typing things correctly.

fix #121